### PR TITLE
BAH-3975 | Fix. Drug form defaults to match concept names

### DIFF
--- a/openmrs/apps/clinical/medication.json
+++ b/openmrs/apps/clinical/medication.json
@@ -43,18 +43,18 @@
         ],
         "drugFormDefaults": {
           "Ayurvedic": {
-            "doseUnits": "Teaspoon(s)",
+            "doseUnits": "Teaspoon",
             "route": "Oral"
           },
           "Capsule": {
-            "doseUnits": "Cap(s)",
+            "doseUnits": "Capsule",
             "route": "Oral"
           },
           "Cream": {
             "route": "Topical"
           },
           "Drops": {
-            "doseUnits": "Drop(s)",
+            "doseUnits": "Drop",
             "route": "Topical"
           },
           "Food Supplement": {
@@ -65,7 +65,7 @@
             "route": "Topical"
           },
           "Granule": {
-            "doseUnits": "Unit(s)",
+            "doseUnits": "Unit",
             "route": "Oral"
           },
           "Inhaler": {
@@ -110,7 +110,7 @@
             "route": "Oral"
           },
           "Tablet": {
-            "doseUnits": "Tablet(s)",
+            "doseUnits": "Tablet",
             "route": "Oral"
           }
         }


### PR DESCRIPTION
This PR fixes the drug form and dosing units defaults as after retiring the custom concepts for dosing units https://github.com/Bahmni/standard-config/commit/54148457ef589cbe91426e73519a912c3576339e#diff-e81d933eee60f050c071f33770b7987fc78bfb15b15003d9ae656540f2ba0f79, the CIEL concept fully specified name is used as default.