### PR TITLE
BAH-4065 | Fix. Concept names for Vital display control in IPD dashboard

### DIFF
--- a/openmrs/apps/ipdDashboard/app.json
+++ b/openmrs/apps/ipdDashboard/app.json
@@ -136,25 +136,25 @@
   "vitalsConfig": {
     "latestVitalsConceptValues": {
       "spO2": "Arterial Blood Oxygen Saturation (Pulse Oximeter)",
-      "weight": "Weight",
-      "bmi": "BMI",
+      "weight": "Weight (kg)",
+      "bmi": "Body mass index",
       "respiratoryRate": "Respiratory Rate",
       "systolicPressure": "Systolic blood pressure",
       "diastolicPressure": "Diastolic blood pressure",
       "temperature": "Temperature",
       "pulse": "Pulse",
-      "height": "Height"
+      "height": "Height (cm)"
     },
     "vitalsHistoryConceptValues": {
       "spO2": "Arterial Blood Oxygen Saturation (Pulse Oximeter)",
-      "weight": "Weight",
-      "bmi": "BMI",
+      "weight": "Weight (kg)",
+      "bmi": "Body mass index",
       "respiratoryRate": "Respiratory Rate",
       "systolicPressure": "Systolic blood pressure",
       "diastolicPressure": "Diastolic blood pressure",
       "temperature": "Temperature",
       "pulse": "Pulse",
-      "height": "Height",
+      "height": "Height (cm)",
       "muac": "Mid-upper arm circumference"
     }
   }


### PR DESCRIPTION
This PR fixes the concept names for the observations that are shown in `Vitals` display control in the IPD Dashboard.