### PR TITLE
BAH-4105 | Add. Hide Form Name Toggle

### DIFF
--- a/openmrs/apps/clinical/app.json
+++ b/openmrs/apps/clinical/app.json
@@ -23,6 +23,7 @@
         "visitUuid"
     ],
     "config": {
+        "hideFormName": true,
         "hideConditions": false,
         "enableRadiologyOrderOptions":["Urgent","NeedsPrint"],
         "enableLabOrderOptions":["Urgent", "NeedsPrint"],

--- a/openmrs/apps/registration/app.json
+++ b/openmrs/apps/registration/app.json
@@ -49,6 +49,7 @@
                     "landHolding": 2
                 }
             },
+            "hideFormName": true,
             "addressHierarchy": {
                 "showAddressFieldsTopDown": false,
                 "strictAutocompleteFromLevel": "stateProvince"


### PR DESCRIPTION
JIRA -> [BAH-4105](https://bahmni.atlassian.net/browse/BAH-4105)


This PR introduces an optional configuration option to hide the form name from the Obs Display Control. By setting the `"hideFormName": true` to the relevant configuration file, the form name will no longer be displayed, ensuring only observation details are shown. By default the form name will be visible.

| `"hideFormName": true` | `"hideFormName": false` |
|-|-|
| ![Screenshot 2025-01-06 at 2 36 27 PM](https://github.com/user-attachments/assets/90c9519e-e80a-4a35-a6c0-0ae7057dc6f7) | ![Screenshot 2025-01-06 at 2 38 23 PM](https://github.com/user-attachments/assets/db58c6f6-c9fa-4ccf-99f6-8d2f94533046) |


