### PR TITLE
BAH-4393 | Add. Liquibase to populate fhir_concept_source for CVX code system

### DIFF
--- a/masterdata/configuration/liquibase/liquibase.xml
+++ b/masterdata/configuration/liquibase/liquibase.xml
@@ -353,4 +353,26 @@
         </sql>
 
     </changeSet>
+
+    <changeSet id="insert-fhir-concept-source-hl7-cvx-202601191000" author="Mohan" runAlways="true">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="fhir_concept_source"/>
+            <tableExists tableName="concept_reference_source"/>
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*) FROM concept_reference_source WHERE name = 'HL-7-CVX'
+            </sqlCheck>
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM fhir_concept_source WHERE url = 'http://hl7.org/fhir/sid/cvx'
+            </sqlCheck>
+        </preConditions>
+        <comment>Add FHIR concept source mapping for HL-7-CVX</comment>
+        <insert tableName="fhir_concept_source">
+            <column name="concept_source_id" valueComputed="(SELECT concept_source_id FROM concept_reference_source WHERE name = 'HL-7-CVX')"/>
+            <column name="url" value="http://hl7.org/fhir/sid/cvx"/>
+            <column name="name" value="HL-7-CVX"/>
+            <column name="creator" value="1"/>
+            <column name="date_created" valueDate="${now}"/>
+            <column name="uuid" valueComputed="${uuid_function}"/>
+        </insert>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds a liquibase changeset which populates the `fhir_concept_source` table for the CVX code system which is used to filter vaccination/immunization orders

JIRA: https://bahmni.atlassian.net/browse/BAH-4393