### PR TITLE
BAH-4393 | Fix. Liquibase version for liquibase.xml file in masterdata

### DIFF
--- a/masterdata/configuration/liquibase/liquibase.xml
+++ b/masterdata/configuration/liquibase/liquibase.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-                  http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <!-- This is a database agnostic liquibase properties configuration for different dbms -->
+    <property name="now" value="now()" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="current_timestamp" dbms="postgresql"/>
+    <property name="uuid_function" value="uuid_generate_v4()" dbms="postgresql"/>
+    <property name="uuid_function" value="uuid()" dbms="mysql,mariadb,h2"/>
     <!-- This changeset is temporary and to be deleted in production when setting up clinics (onboarding users) -->
 	<changeSet id="bah-1570-20220427-1" author="Deepthi,Soorya">
     	<preConditions onFail="MARK_RAN">


### PR DESCRIPTION
This PR upgrades the liquibase schema version to 3.8 from 1.9 and added support functions like uuid() , now() agnostic of database.

JIRA: https://bahmni.atlassian.net/browse/BAH-4393