### PR TITLE
BAH-4332 Create a Documents display control

### DIFF
--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -1,3 +1,4 @@
+
 {
   "sections": [
     {
@@ -50,7 +51,7 @@
     {
       "name": "Documents",
       "translationKey": "DOCUMENTS_TABLE_HEADING",
-      "icon": "fa-file-pdf",
+      "icon": "fa-file-alt",
       "controls": [
         {
           "type": "patientDocuments"

--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -54,7 +54,15 @@
       "icon": "fa-file-alt",
       "controls": [
         {
-          "type": "patientDocuments"
+          "type": "patientDocuments",
+          "config": {
+            "fields": [
+              "documentIdentifier",
+              "documentType",
+              "uploadedOn",
+              "uploadedBy"
+            ]
+          }
         }
       ]
     },

--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -48,6 +48,16 @@
       ]
     },
     {
+      "name": "Documents",
+      "translationKey": "DOCUMENTS_TABLE_HEADING",
+      "icon": "fa-file-pdf",
+      "controls": [
+        {
+          "type": "patientDocuments"
+        }
+      ]
+    },
+    {
       "name": "Programs",
       "translationKey": "DASHBOARD_TITLE_PROGRAMS_KEY",
       "icon": "fa-clipboard-list",

--- a/openmrs/apps/documentUpload/extension-RADIOLOGY.json
+++ b/openmrs/apps/documentUpload/extension-RADIOLOGY.json
@@ -5,7 +5,7 @@
         "type": "config",
         "extensionParams": {
             "searchHandler": "emrapi.sqlSearch.activePatients",
-            "translationKey": "MODULE_LABEL_ACTIVE_PATIENTS_KEY",
+            "translationKey": " ",
             "forwardUrl" : "#/patient/{{patientUuid}}/document"
         },
         "label": "Active Patients",

--- a/openmrs/apps/documentUpload/extension-RADIOLOGY.json
+++ b/openmrs/apps/documentUpload/extension-RADIOLOGY.json
@@ -5,7 +5,7 @@
         "type": "config",
         "extensionParams": {
             "searchHandler": "emrapi.sqlSearch.activePatients",
-            "translationKey": " ",
+            "translationKey": "MODULE_LABEL_ACTIVE_PATIENTS_KEY",
             "forwardUrl" : "#/patient/{{patientUuid}}/document"
         },
         "label": "Active Patients",


### PR DESCRIPTION
## Description

This card focuses on creating a display control to display the documents recorded for a patient.

User story: 

As a clinical user,
I want to view documents recorded for a patient directly from the patient dashboard,
so that I can quickly access clinical documents such as prescriptions, discharge summaries, and diagnostic reports without navigating away from the patient record. A Documents display control, thus shall be added to the Patient Dashboard in the Clinical module to display all documents uploaded for a patient.

The control displays document metadata and allows users to open documents securely.
