### PR TITLE
BAH-4448|Update privileges for Documents Display Control

### DIFF
--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -55,7 +55,10 @@
       "controls": [
         {
           "type": "patientDocuments",
-          "requiredPrivileges": ["Get Patient Documents", "View Patient Documents"],
+          "requiredPrivileges": [
+            "Get DocumentReference",
+            "View DocumentReference"
+          ],
           "config": {
             "fields": [
               "documentIdentifier",


### PR DESCRIPTION
### Updated Privileges for Documents Display Control

To enable a user to view the Documents Display Control, grant the following privileges:

[Get DocumentReference](https://docker.standard.mybahmni.in/openmrs/admin/users/privilege.form?privilege=Get%20DocumentReference)

[View DocumentReference](https://docker.standard.mybahmni.in/openmrs/admin/users/privilege.form?privilege=View%20DocumentReference)