### PR TITLE
BAH-4550, BAH-4551 | Add. Immunization Section In General Dashboard

### DIFF
--- a/masterdata/configuration/encountertypes/encountertypes.csv
+++ b/masterdata/configuration/encountertypes/encountertypes.csv
@@ -1,0 +1,2 @@
+Uuid,Void/Retire,Name,Description,View privilege,Edit privilege,_order:1000
+e152f007-ba30-4bb0-828c-710927a01be6,,Immunization,An encounter for recording patient immunizations.,,,

--- a/masterdata/configuration/liquibase/liquibase.xml
+++ b/masterdata/configuration/liquibase/liquibase.xml
@@ -381,4 +381,7 @@
             <column name="uuid" valueComputed="${uuid_function}"/>
         </insert>
     </changeSet>
+
+    <include file="override_ciel_immunization_valueset.xml" relativeToChangelogFile="true"/>
+    <include file="override_ciel_vaccination_site_valueset.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/masterdata/configuration/liquibase/override_ciel_immunization_valueset.xml
+++ b/masterdata/configuration/liquibase/override_ciel_immunization_valueset.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="setup_immunization_is_set_240420261730" author="angshu, pratiti">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">SELECT COUNT(*) FROM concept WHERE uuid = '984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'</sqlCheck>
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM concept WHERE uuid = '984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' AND is_set = 1</sqlCheck>
+        </preConditions>
+        <comment>mark immunization concept as a set (984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)</comment>
+        <sql>
+            UPDATE concept SET is_set = 1 WHERE uuid = '984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+        </sql>
+    </changeSet>
+
+    <changeSet id="setup_immunization_set_members_240420261730" author="angshu, pratiti">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">SELECT COUNT(*) FROM concept WHERE uuid = '984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'</sqlCheck>
+        </preConditions>
+        <comment>add answers as set members for immunization (984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)</comment>
+        <sql>
+            SET @immunization_valueset_id = 0;
+            SELECT concept_id into @immunization_valueset_id from concept where uuid = '984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+            INSERT INTO concept_set (concept_set, concept_id, sort_weight, creator, date_created, uuid)
+                SELECT @immunization_valueset_id, ca.answer_concept, ca.sort_weight, 1, NOW(), UUID()
+                FROM concept_answer ca
+                WHERE ca.concept_id = @immunization_valueset_id
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM concept_set
+                    WHERE concept_set = @immunization_valueset_id
+                    AND concept_id = ca.answer_concept
+                );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/masterdata/configuration/liquibase/override_ciel_vaccination_site_valueset.xml
+++ b/masterdata/configuration/liquibase/override_ciel_vaccination_site_valueset.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="setup_vaccination_site_is_set_270420261730" author="angshu, pratiti">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">SELECT COUNT(*) FROM concept WHERE uuid = '280cbf8c-aff5-4753-a281-61e14d2c622a'</sqlCheck>
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM concept WHERE uuid = '280cbf8c-aff5-4753-a281-61e14d2c622a' AND is_set = 1</sqlCheck>
+        </preConditions>
+        <comment>mark vaccination body site concept as a set (280cbf8c-aff5-4753-a281-61e14d2c622a)</comment>
+        <sql>
+            UPDATE concept SET is_set = 1 WHERE uuid = '280cbf8c-aff5-4753-a281-61e14d2c622a';
+        </sql>
+    </changeSet>
+
+    <changeSet id="setup_vaccination_site_set_members_270420261730" author="angshu, pratiti">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">SELECT COUNT(*) FROM concept WHERE uuid = '280cbf8c-aff5-4753-a281-61e14d2c622a'</sqlCheck>
+        </preConditions>
+        <comment>add answers as set members for vaccination body site (280cbf8c-aff5-4753-a281-61e14d2c622a)</comment>
+        <sql>
+            SET @vaccination_site_id = 0;
+            SELECT concept_id into @vaccination_site_id from concept where uuid = '280cbf8c-aff5-4753-a281-61e14d2c622a';
+
+            INSERT INTO concept_set (concept_set, concept_id, sort_weight, creator, date_created, uuid)
+                SELECT @vaccination_site_id, ca.answer_concept, ca.sort_weight, 1, NOW(), UUID()
+                FROM concept_answer ca
+                WHERE ca.concept_id = @vaccination_site_id
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM concept_set
+                    WHERE concept_set = @vaccination_site_id
+                    AND concept_id = ca.answer_concept
+                );
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/masterdata/configuration/locationtags/locationtags.csv
+++ b/masterdata/configuration/locationtags/locationtags.csv
@@ -1,0 +1,2 @@
+Uuid,Void/Retire,Name,Description
+1297bff4-d92d-4de8-95d3-a27134adc2b4,,Immunization Location,Tag for locations where immunizations are administered

--- a/masterdata/configuration/privileges/privileges.csv
+++ b/masterdata/configuration/privileges/privileges.csv
@@ -1,3 +1,4 @@
 Uuid,Privilege name,Description
 ,app:atomfeed-console,Able to access atomfeed console.
 ,Send SMS,Privilege to send SMS
+,app:clinical:addImmunizations,Privilege to add immunizations in clinical module.

--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -77,9 +77,9 @@
     "immunizationHistory": {
       "metadata": {
         "administeredLocationTag": "Visit Location",
-        "routeConceptUuid": "d462489d-5e07-11ef-8f7c-0242ac120002",
+        "routeConceptUuid": "162394AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "vaccineConceptSetUuid": "984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        "siteConceptUuid": "9cc9ed5b-0926-4abf-a00f-c1d62d305c5f"
+        "siteConceptUuid": "280cbf8c-aff5-4753-a281-61e14d2c622a"
       },
       "encounterTypes": ["Immunization"],
       "privileges": ["Get Immunizations", "Add Immunizations"],
@@ -90,7 +90,7 @@
         },
         {
           "name": "administeredLocation",
-          "required": true
+          "required": false
         },
         {
           "name": "route",
@@ -98,7 +98,7 @@
         },
         {
           "name": "site",
-          "required": true
+          "required": false
         },
         {
           "name": "expiryDate",
@@ -110,7 +110,7 @@
         },
         {
           "name": "batchNumber",
-          "required": true
+          "required": false
         }
       ]
     }

--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -29,6 +29,93 @@
       "environmentalAllergenUuid": "162554AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "allergyReactionUuid": "162555AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
     },
-    "statDurationInMilliseconds": 7200000 
+    "statDurationInMilliseconds": 7200000,
+    "encounterDetails": {
+      "metadata": {
+        "defaultEncounterType": "Consultation"
+      },
+      "encounterTypes": ["Consultation"],
+      "privileges": ["Add Encounters"],
+      "attributes": []
+    },
+    "allergies": {
+      "metadata": {},
+      "encounterTypes": ["Consultation"],
+      "privileges": ["Add Allergies"],
+      "attributes": []
+    },
+    "investigations": {
+      "metadata": {},
+      "encounterTypes": ["Consultation"],
+      "privileges": ["Add Orders"],
+      "attributes": []
+    },
+    "medications": {
+      "metadata": {},
+      "encounterTypes": ["Consultation"],
+      "privileges": ["Add Orders"],
+      "attributes": []
+    },
+    "observationForms": {
+      "metadata": {},
+      "encounterTypes": ["Consultation"],
+      "privileges": ["Add Observations"],
+      "attributes": []
+    },
+    "vaccinations": {
+      "metadata": {},
+      "encounterTypes": ["Consultation"],
+      "privileges": ["Add Orders"],
+      "attributes": []
+    },
+    "conditionsAndDiagnoses": {
+      "metadata": {},
+      "encounterTypes": ["Consultation"],
+      "privileges": ["Add Diagnoses"],
+      "attributes": []
+    },
+    "immunizationHistory": {
+      "metadata": {
+        "administeredLocationTag": "Visit Location",
+        "routeConceptUuid": "d462489d-5e07-11ef-8f7c-0242ac120002",
+        "vaccineConceptSetUuid": "984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "siteConceptUuid": "9cc9ed5b-0926-4abf-a00f-c1d62d305c5f"
+      },
+      "encounterTypes": ["Immunization"],
+      "privileges": ["Get Immunizations", "Add Immunizations"],
+      "attributes": [
+        {
+          "name": "administeredOn",
+          "required": true
+        },
+        {
+          "name": "administeredLocation",
+          "required": true,
+          "administeredLocationTag": "Visit Location"
+        },
+        {
+          "name": "route",
+          "required": false,
+          "routeConceptUuid": "d462489d-5e07-11ef-8f7c-0242ac120002"
+        },
+        {
+          "name": "site",
+          "required": true,
+          "siteConceptUuid": "9cc9ed5b-0926-4abf-a00f-c1d62d305c5f"
+        },
+        {
+          "name": "expiryDate",
+          "required": false
+        },
+        {
+          "name": "manufacturer",
+          "required": false
+        },
+        {
+          "name": "batchNumber",
+          "required": true
+        }
+      ]
+    }
   }
 }

--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -90,18 +90,15 @@
         },
         {
           "name": "administeredLocation",
-          "required": true,
-          "administeredLocationTag": "Visit Location"
+          "required": true
         },
         {
           "name": "route",
-          "required": false,
-          "routeConceptUuid": "d462489d-5e07-11ef-8f7c-0242ac120002"
+          "required": false
         },
         {
           "name": "site",
-          "required": true,
-          "siteConceptUuid": "9cc9ed5b-0926-4abf-a00f-c1d62d305c5f"
+          "required": true
         },
         {
           "name": "expiryDate",

--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -76,7 +76,7 @@
     },
     "immunizationHistory": {
       "metadata": {
-        "administeredLocationTag": "Visit Location",
+        "administeredLocationTag": "Immunization Location",
         "routeConceptUuid": "162394AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "vaccineConceptSetUuid": "984AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         "siteConceptUuid": "280cbf8c-aff5-4753-a281-61e14d2c622a"

--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -48,6 +48,16 @@
       ]
     },
     {
+      "name": "Immunization",
+      "translationKey": "DASHBOARD_TITLE_IMMUNISATION_KEY",
+      "icon": "fa-syringe",
+      "controls": [
+        {
+          "type": "immunizationHistory"
+        }
+      ]
+    },
+    {
       "name": "Documents",
       "translationKey": "DOCUMENTS_TABLE_HEADING",
       "icon": "fa-file-alt",
@@ -139,6 +149,12 @@
         {
           "type": "treatment",
           "requiredPrivileges": ["Get Orders"]
+        },
+        {
+          "type": "treatment",
+          "config": {
+            "code": ["http://hl7.org/fhir/sid/cvx|"]
+          }
         }
       ]
     },

--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -53,7 +53,11 @@
       "icon": "fa-syringe",
       "controls": [
         {
-          "type": "immunizationHistory"
+          "type": "immunizationHistory",
+          "config": {
+            "encounterType": "Immunization",
+            "startEncounterPrivilege": "app:clinical:addImmunizations"
+          }
         }
       ]
     },
@@ -149,12 +153,6 @@
         {
           "type": "treatment",
           "requiredPrivileges": ["Get Orders"]
-        },
-        {
-          "type": "treatment",
-          "config": {
-            "code": ["http://hl7.org/fhir/sid/cvx|"]
-          }
         }
       ]
     },


### PR DESCRIPTION
**JIRA** → [BAH-4550](https://bahmni.atlassian.net/browse/BAH-4550)

This PR introduces a new Immunization section and the Immunization History display control that displays the immunizations for a patient.

## Masterdata / Initializer
  - Added Immunization encounter type via encountertypes.csv
  - Added app:clinical:addImmunizations privilege via privileges.csv
  - Added Immunization Location location tag via locationtags/locationtags.csv

## Liquibase Migrations
  - Added override_ciel_immunization_valueset.xml: marks CIEL concept 984AAA... as a set and copies its answers as set members
  - Added override_ciel_vaccination_site_valueset.xml: same pattern for vaccination body site concept 280cbf8c-...
  - Included both files in liquibase.xml

[BAH-4550]: https://bahmni.atlassian.net/browse/BAH-4550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ