### PR TITLE
BAH-4565 | Update default pageSize to 5

### DIFF
--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -63,7 +63,7 @@
               "uploadedBy",
               "action"
             ],
-            "pageSize": 10
+            "pageSize": 5
           }
         }
       ]
@@ -85,7 +85,7 @@
               "outcome",
               "state"
             ],
-            "pageSize": 10
+            "pageSize": 5
           }
         }
       ]
@@ -114,14 +114,14 @@
           "type": "conditions",
           "requiredPrivileges": ["Get Conditions"],
           "config": {
-            "pageSize": 10
+            "pageSize": 5
           }
         },
         {
           "type": "diagnoses",
           "requiredPrivileges": ["Get Diagnoses"],
           "config": {
-            "pageSize": 10
+            "pageSize": 5
           }
         }
       ]


### PR DESCRIPTION
## Summary
- Updates the default pageSize to 5 for display controls with SortableDataTable

## Test plan
- [ ] Verify pagination with pageSize 5 works correctly across all affected display controls
- [ ] Check DiagnosesTable, ConditionsTable, PatientProgramsTable, and DocumentsTable

🤖 Generated with [Claude Code](https://claude.com/claude-code)