### PR TITLE
BAH-4638 | Add extension.json for new homepage

### DIFF
--- a/openmrs/apps/home/v2/extension.json
+++ b/openmrs/apps/home/v2/extension.json
@@ -1,0 +1,144 @@
+{
+  "registrationNew": {
+    "id": "bahmni.registration.new",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_REGISTRATION_KEY",
+    "url": "registration/search",
+    "icon": "fa-user",
+    "order": 1,
+    "requiredPrivilege": "app:registration"
+  },
+  "programs": {
+    "id": "bahmni.programs",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_PROGRAMS_KEY",
+    "url": "/bahmni/clinical/#/programs/patient/search",
+    "icon": "fa-hands-holding-child",
+    "order": 2,
+    "requiredPrivilege": "app:clinical"
+  },
+  "clinical": {
+    "id": "bahmni.clinical",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_CLINICAL_KEY",
+    "url": "clinical/index.html#/default/patient/search",
+    "icon": "fa-stethoscope",
+    "order": 3,
+    "requiredPrivilege": "app:clinical"
+  },
+   "radiologyDocumentUpload": {
+    "id": "bahmni.radiology.document.upload",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_RADIOLOGY_UPLOAD_KEY",
+    "url": "/bahmni/document-upload/?encounterType=RADIOLOGY&topLevelConcept=All Radiology orders",
+    "icon": "fa-x-ray",
+    "order": 4,
+    "requiredPrivilege": "app:radiology-upload"
+  },
+   "patientDocumentUpload": {
+    "id": "bahmni.patient.document.upload",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_PATIENT_DOCUMENTS_KEY",
+    "url": "/bahmni/document-upload/?encounterType=Patient Document&topLevelConcept=Patient Document&defaultOption=Patient file",
+    "icon": "fa-file-medical",
+    "order": 5,
+    "requiredPrivilege": "app:patient-documents"
+  },
+  "bahmniIpd": {
+    "id": "bahmni.ipd",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_BED_MANAGEMENT_KEY",
+    "label": "InPatient",
+    "url": "/bahmni/bedmanagement/#/home",
+    "icon": "fa-bed",
+    "order": 6,
+    "requiredPrivilege": "app:adt"
+  },
+  "admin": {
+    "id": "bahmni.admin",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_ADMIN_KEY",
+    "url": "/bahmni/admin/#/dashboard/home",
+    "icon": "fa-user-gear",
+    "order": 7,
+    "requiredPrivilege": "app:admin"
+  },
+   "reports": {
+    "id": "bahmni.reports",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_REPORTS_KEY",
+    "url": "/bahmni/reports/#/dashboard",
+    "icon": "fa-file-lines",
+    "order": 8,
+    "requiredPrivilege": "app:reports"
+  },
+   "bahmniOT": {
+    "id": "bahmni.ot",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "Operation Theatre",
+    "url": "/bahmni/ot/",
+    "icon": "fa-hospital",
+    "order": 9,
+    "requiredPrivilege": "app:ot"
+  },
+  "orders": {
+    "id": "bahmni.orders",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_ORDERS_KEY",
+    "url": "/bahmni/orders/#/search",
+    "icon": "fa-clipboard-list",
+    "order": 10,
+    "requiredPrivilege": "app:orders"
+  },
+  "implementerInterface": {
+    "id": "bahmni.implementer.interface",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_IMPLEMENTER_INTERFACE_KEY",
+    "url": "/implementer-interface/#",
+    "icon": "fa-pen-to-square",
+    "order": 11,
+    "requiredPrivilege": "app:implementer-interface"
+  },
+  "atomfeedConsole": {
+    "id": "bahmni.atomfeed.console",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_ATOMFEED_CONSOLE_KEY",
+    "url": "/atomfeed-console",
+    "icon": "fa-terminal",
+    "order": 12,
+    "requiredPrivilege": "app:admin"
+  },
+  "appointmentScheduling": {
+    "id": "bahmni.appointment.scheduling",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_APPOINTMENT_SCHEDULING_KEY",
+    "url": "/appointments/#/home/manage/summary",
+    "icon": "fa-calendar-days",
+    "order": 13,
+    "requiredPrivilege": "app:appointments"
+  },
+  "labLite": {
+    "id": "bahmni.lab",
+    "extensionPointId": "org.bahmni.home.dashboard",
+    "type": "link",
+    "translationKey": "MODULE_LABEL_LAB_ENTRY_KEY",
+    "url": "/lab",
+    "icon": "fa-flask",
+    "order": 14,
+    "requiredPrivilege": "app:lab-lite",
+    "captureTestResults": true
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `extension.json` configuration file under `openmrs/apps/home/v2/` that drives the tile/module data for the new React-based homepage. 

## Jira Cards

- [BAH-4519](https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/131?selectedIssue=BAH-4519)
- [BAH-4638](https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/131?selectedIssue=BAH-4638)

## Changes

- Added `openmrs/apps/home/v2/extension.json` with tile definitions for all homepage modules:
- Each tile entry includes `id`, `extensionPointId`, `translationKey`, `url`, `icon`, `order`, and `requiredPrivilege` so it can be rendered and access-controlled dynamically by the new homepage.
- Updated module navigation URLs to align with the new React homepage routing.

[BAH-4519]: https://bahmni.atlassian.net/browse/BAH-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BAH-4638]: https://bahmni.atlassian.net/browse/BAH-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ