### PR TITLE
BAH-4550 | Add. Dose Sequence To Immunization History Config

### DIFF
--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -89,6 +89,10 @@
           "required": true
         },
         {
+          "name": "doseSequence",
+          "required": false
+        },
+        {
           "name": "administeredOn",
           "required": true
         },


### PR DESCRIPTION
JIRA → [BAH-4550](https://bahmni.atlassian.net/browse/BAH-4550)

## Description

Extends the Immunization History form with a new optional Dose Sequence field in the immunization entry form that maps to the FHIR protocolApplied.doseNumberPositiveInt field on submission.

[BAH-4550]: https://bahmni.atlassian.net/browse/BAH-4550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ