### PR TITLE
BAH-4654 | Add. Edit Configurations for Medications

### DIFF
--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -171,7 +171,17 @@
       "controls": [
         {
           "type": "treatment",
-          "requiredPrivileges": ["Get Orders"]
+          "requiredPrivileges": ["Get Orders"],
+          "config": {
+            "actions": [
+              {
+                "label": "Edit",
+                "type": "edit",
+                "encounterType": "Consultation",
+                "requiredPrivilege": ["Edit Orders"]
+              }
+            ]
+          }
         }
       ]
     },

--- a/openmrs/apps/clinical/v2/dashboards/program.json
+++ b/openmrs/apps/clinical/v2/dashboards/program.json
@@ -96,7 +96,16 @@
             "controls": [
                 {
                     "type": "treatment",
-                    "config": {}
+                    "config": {
+                        "actions": [
+                            {
+                                "label": "Edit",
+                                "type": "edit",
+                                "encounterType": "Consultation",
+                                "requiredPrivilege": ["Edit Orders"]
+                            }
+                        ]
+                    }
                 }
             ]
         }


### PR DESCRIPTION
## Summary

Adds edit action configuration for the Medications widget in the standard-config dashboard JSON files.

## Changes

- **`general.json`** — adds `config.actions` array to the Medications `treatment` control:
  ```json
  "actions": [{
    "label": "Edit",
    "type": "edit",
    "encounterType": "Consultation",
    "requiredPrivilege": ["Edit Orders"]
  }]
  ```
- **`program.json`** — same change for the program dashboard

## How it works

The frontend `MedicationsTable` widget reads `config.actions` from the dashboard JSON. When an action with `type: "edit"` is present, the widget renders:
- An "Edit All" button in the section header (gated by `requiredPrivilege`)
- Per-row edit actions in the overflow menu (for medications in the active encounter)

This is config-driven — removing the `actions` block disables edit entirely without code changes.

## Related PRs
| Repo | PR | Purpose |
|------|----|---------|
| bahmni-apps-frontend | [#411](https://github.com/Bahmni/bahmni-apps-frontend/pull/411) | Frontend: Edit Medications feature |
| bahmni-module-fhir2-addl-extension | [#71](https://github.com/Bahmni/bahmni-module-fhir2-addl-extension/pull/71) | Backend: priorPrescription translation |
| clinic-config | [#253](https://github.com/Bahmni/clinic-config/pull/253) | Same config for clinic deployment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)