### PR TITLE
BAH-4694.Fix: SQL Queries for diagnosisCount post FHIR v4 migration

### DIFF
--- a/openmrs/apps/reports/sql/diagnosisCount.sql
+++ b/openmrs/apps/reports/sql/diagnosisCount.sql
@@ -51,12 +51,12 @@ from
    SUM(IF(person.gender = 'M', 1, 0))       AS male,
    SUM(IF(person.gender = 'O', 1, 0))       AS other,
    SUM(IF(person.gender = 'U', 1, 0))       AS undisclosed,
-   ed.date_created                          AS obs_datetime
+   enc.encounter_datetime                   AS obs_datetime
    FROM encounter_diagnosis ed
    JOIN encounter enc ON enc.encounter_id = ed.encounter_id AND enc.voided = FALSE
    JOIN person ON person.person_id = enc.patient_id AND person.voided = FALSE
-   WHERE ed.certainty IN ('CONFIRMED', 'PRESUMED')
-   AND cast(ed.date_created AS DATE) BETWEEN '#startDate#' AND '#endDate#'
+   WHERE ed.certainty IN ('CONFIRMED', 'PROVISIONAL')
+   AND cast(enc.encounter_datetime AS DATE) BETWEEN '#startDate#' AND '#endDate#'
    AND ed.voided = FALSE GROUP BY ed.diagnosis_coded)
    ) as diagnosisObs
 

--- a/openmrs/apps/reports/sql/diagnosisCount.sql
+++ b/openmrs/apps/reports/sql/diagnosisCount.sql
@@ -41,8 +41,24 @@ from
    JOIN person on patient_conditions.patient_id = person.person_id
    WHERE patient_conditions.clinical_status = 'ACTIVE'
    AND cast(patient_conditions.date_created AS DATE) BETWEEN '#startDate#' AND '#endDate#' 
-   AND patient_conditions.voided = FALSE AND person.voided = FALSE group by patient_conditions.condition_coded
-   )) as diagnosisObs
+   AND patient_conditions.voided = FALSE AND person.voided = FALSE group by patient_conditions.condition_coded)
+
+   UNION
+
+   (SELECT
+   ed.diagnosis_coded                       AS value_coded,
+   SUM(IF(person.gender = 'F', 1, 0))       AS female,
+   SUM(IF(person.gender = 'M', 1, 0))       AS male,
+   SUM(IF(person.gender = 'O', 1, 0))       AS other,
+   SUM(IF(person.gender = 'U', 1, 0))       AS undisclosed,
+   ed.date_created                          AS obs_datetime
+   FROM encounter_diagnosis ed
+   JOIN encounter enc ON enc.encounter_id = ed.encounter_id AND enc.voided = FALSE
+   JOIN person ON person.person_id = enc.patient_id AND person.voided = FALSE
+   WHERE ed.certainty IN ('CONFIRMED', 'PRESUMED')
+   AND cast(ed.date_created AS DATE) BETWEEN '#startDate#' AND '#endDate#'
+   AND ed.voided = FALSE GROUP BY ed.diagnosis_coded)
+   ) as diagnosisObs
 
 JOIN concept_name cn on cn.concept_id = diagnosisObs.value_coded
 AND cn.concept_name_type = 'FULLY_SPECIFIED' AND cn.locale = 'en' AND cn.voided = FALSE group by cn.name;


### PR DESCRIPTION
**Summary**

Fixes the diagnosisCount reports that was broken for Bahmni standard after the move to FHIR v4. The FHIR module stores diagnoses in the encounter_diagnosis table. The existing SQL queries only read from obs and conditions tables, causing newly entered diagnoses to be missing from reports.

**Changes**

diagnosisCount.sql: Added a UNION subquery that reads from encounter_diagnosis joined with encounter and person, filtering on certainty IN('CONFIRMED', 'PRESUMED') and the same date range and voided constraints. Results are merged with the existing query before the final concept_name join.

**Why**

After the FHIR v4 migration, clinical data entered via the React frontend is persisted to encounter_diagnosis. Without this fix, any diagnosis recorded through the new frontend was invisible to these reports.

**Jira**

[BAH-4694](https://bahmni.atlassian.net/browse/BAH-4694?atlOrigin=eyJpIjoiYTdiY2Q5ZGYwNDU5NGQ1MjhhMjdhYTUzYjAxOWY3OWMiLCJwIjoiaiJ9)

[BAH-4694]: https://bahmni.atlassian.net/browse/BAH-4694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ