### PR TITLE
BAH-4734 | Add sample CDSS config for clinical

### DIFF
--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -96,7 +96,8 @@
           { "name": "instruction", "required": false },
           { "name": "startDate", "required": true },
           { "name": "note", "required": false }
-        ]
+        ],
+        "cdss":[]
       },
       {
         "type": "observationForms",

--- a/openmrs/apps/clinical/v2/cdss-servers.json
+++ b/openmrs/apps/clinical/v2/cdss-servers.json
@@ -1,0 +1,18 @@
+[
+    {
+      "server": "clinical-example-cdss",
+      "url": "/openmrs/ws/rest/v1/clinical-example-cdss/cdss",
+      "services": [
+        {
+          "name": "vaccine-order-select",
+          "description": "CDSS service to provide decision support for vaccine order entry",
+          "contextResourceMap": [
+            {
+              "type": "MedicationRequest",
+              "attribute": "draftOrders"
+            }
+          ]
+        }
+      ]
+    }
+  ]


### PR DESCRIPTION
Purpose

  This PR provides a reference implementation for CDSS integration that can be customized for specific clinical decision support requirements in implementations.

  Technical Details

  CDSS Server Configuration (cdss-servers.json)
  - Defines CDSS server endpoints and available services
  - Maps context resources (e.g., MedicationRequest) to appropriate attributes (e.g., draftOrders)

  Input Control Integration (app.json)
  CDSS rules can be added to any input control by configuring the cdss array:
  "cdss": [
    {
      "event": "onSelect",
      "server": "clinical-example-cdss",
      "service": "vaccine-order-select"
    }
  ]
  - event: Trigger point for CDSS service (e.g., onSelect, onChange)
  - server: References the CDSS server defined in cdss-servers.json
  - service: Specifies which CDSS service to invoke

  Usage Example

  To enable CDSS for a specific workflow:
  1. Define the CDSS server and services in cdss-servers.json
  2. Add CDSS hooks to the relevant input control in app.json
  3. The CDSS service will be triggered based on the configured event

  Testing

  This is a sample configuration that serves as a template. Actual CDSS functionality requires:
  - A running CDSS server at the configured endpoint
  - Appropriate CDSS service implementations
  - Client-specific business logic and rules