### PR TITLE
BAH-4655. fix: Use registrationEncounterType instead of registrationEncounterTypeUuid

### DIFF
--- a/openmrs/apps/registration/v2/app.json
+++ b/openmrs/apps/registration/v2/app.json
@@ -198,5 +198,5 @@
         "requiredPrivilege": "View Patients"
       }
     ],
-  "registrationEncounterTypeUuid": "d352e230-5e07-11ef-8f7c-0242ac120002"
-  }
+  "registrationEncounterType": "REGISTRATION_ENCOUNTER_TYPE"
+}

--- a/openmrs/apps/registration/v2/app.json
+++ b/openmrs/apps/registration/v2/app.json
@@ -198,5 +198,5 @@
         "requiredPrivilege": "View Patients"
       }
     ],
-  "registrationEncounterTypeUuid": "b9cf04a1-f496-11ed-b02c-0242ac150003"
+  "registrationEncounterTypeUuid": "d352e230-5e07-11ef-8f7c-0242ac120002"
   }

--- a/openmrs/apps/registration/v2/app.json
+++ b/openmrs/apps/registration/v2/app.json
@@ -198,5 +198,5 @@
         "requiredPrivilege": "View Patients"
       }
     ],
-  "registrationEncounterType": "REGISTRATION_ENCOUNTER_TYPE"
+  "registrationEncounterType": "REG"
 }


### PR DESCRIPTION
JIRA → [BAH-4655](https://bahmni.atlassian.net/browse/BAH-4655?atlOrigin=eyJpIjoiNWIwOGM5MWJhZmEwNDU3ZDg4YTVkNWYxZWQ5ZjA4ZWIiLCJwIjoiaiJ9)

Problem
registrationEncounterTypeUuid in clinic-config/openmrs/apps/registration/v2/app.json` was hardcoded to a specific UUID:
UUIDs are installation-specific. This breaks on any OpenMRS instance where the Registration encounter type has a different UUID.

Solution
Store the encounter type name in config instead of UUID. Resolve the UUID at runtime by calling the OpenMRS REST API, the same way the clinical app resolves encounter types via bahmnicore/config/bahmniencounter.

[BAH-4655]: https://bahmni.atlassian.net/browse/BAH-4655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ